### PR TITLE
feat: add support php 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.5]
+        php: [8.2, 8.3, 8.4, 8.5]
         laravel: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.5]
         laravel: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "source": "https://github.com/eXolnet/laravel-status"
     },
     "require": {
-        "php": "8.5.*",
+        "php": "^8.2",
         "illuminate/filesystem": "^11.0|^12.0",
         "illuminate/routing": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "source": "https://github.com/eXolnet/laravel-status"
     },
     "require": {
-        "php": "^8.2",
+        "php": "8.5.*",
         "illuminate/filesystem": "^11.0|^12.0",
         "illuminate/routing": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0"

--- a/tests/Feature/StatusTest.php
+++ b/tests/Feature/StatusTest.php
@@ -14,7 +14,7 @@ class StatusTest extends TestCase
         $response = $this->get('/health');
 
         $response->assertStatus(200);
-        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+        $response->assertHeader('Content-Type', 'text/plain; charset=utf-8');
         $response->assertSeeText('OK');
     }
 
@@ -28,7 +28,7 @@ class StatusTest extends TestCase
         $response = $this->get('/sha');
 
         $response->assertStatus(200);
-        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+        $response->assertHeader('Content-Type', 'text/plain; charset=utf-8');
         $response->assertSeeText('2b21eb3');
 
         File::delete('REVISION');

--- a/tests/Feature/StatusTest.php
+++ b/tests/Feature/StatusTest.php
@@ -14,7 +14,7 @@ class StatusTest extends TestCase
         $response = $this->get('/health');
 
         $response->assertStatus(200);
-        $response->assertHeader('Content-Type', 'text/plain; charset=utf-8');
+        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
         $response->assertSeeText('OK');
     }
 
@@ -28,7 +28,7 @@ class StatusTest extends TestCase
         $response = $this->get('/sha');
 
         $response->assertStatus(200);
-        $response->assertHeader('Content-Type', 'text/plain; charset=utf-8');
+        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
         $response->assertSeeText('2b21eb3');
 
         File::delete('REVISION');

--- a/tests/Feature/StatusTest.php
+++ b/tests/Feature/StatusTest.php
@@ -14,7 +14,10 @@ class StatusTest extends TestCase
         $response = $this->get('/health');
 
         $response->assertStatus(200);
-        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+        $this->assertMatchesRegularExpression(
+            '/^text\/plain; charset=utf-8$/i',
+            $response->headers->get('Content-Type')
+        );
         $response->assertSeeText('OK');
     }
 
@@ -28,7 +31,10 @@ class StatusTest extends TestCase
         $response = $this->get('/sha');
 
         $response->assertStatus(200);
-        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+        $this->assertMatchesRegularExpression(
+            '/^text\/plain; charset=utf-8$/i',
+            $response->headers->get('Content-Type')
+        );
         $response->assertSeeText('2b21eb3');
 
         File::delete('REVISION');


### PR DESCRIPTION
This pull request updates the PHP version requirements for the project to ensure compatibility with the latest PHP release. The changes remove support for older PHP versions and require PHP 8.5 throughout the codebase.

Dependency and compatibility updates:

* Updated the PHP version requirement in `composer.json` to require PHP 8.5 exclusively, dropping support for earlier versions.
* Modified the GitHub Actions workflow in `.github/workflows/tests.yml` to run tests only on PHP 8.5, removing 8.2, 8.3, and 8.4 from the test matrix.
Ref: #57416