### PR TITLE
feat: add support for Laravel 13 and update PHP requirement to 8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,14 +9,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [11.*, 12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "source": "https://github.com/eXolnet/laravel-status"
     },
     "require": {
-        "php": "^8.2",
-        "illuminate/filesystem": "^11.0|^12.0",
-        "illuminate/routing": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0"
+        "php": "^8.3",
+        "illuminate/filesystem": "^11.0|^12.0|^13.0",
+        "illuminate/routing": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",


### PR DESCRIPTION
This pull request updates the package to support newer versions of PHP and Laravel, while dropping support for older PHP versions. The changes ensure compatibility with Laravel 13 and require PHP 8.3 or higher.

Dependency and compatibility updates:

* Updated `composer.json` to require PHP 8.3+ and add support for Laravel 13 by including `^13.0` for `illuminate/filesystem`, `illuminate/routing`, and `illuminate/support` dependencies.

CI configuration updates:

* Modified `.github/workflows/tests.yml` to remove testing for PHP 8.2, add testing for Laravel 13, and ensure the correct version of `testbench` is used for each Laravel version.

Ref: #58872