### PR TITLE
ci: add support for laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   tests:
@@ -11,6 +11,7 @@ jobs:
       matrix:
         php: [8.3, 8.4, 8.5]
         laravel: [11.*, 12.*, 13.*]
+        phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
@@ -19,8 +20,15 @@ jobs:
             testbench: 10.*
           - laravel: 13.*
             testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            phpunit: 12.*
+          - laravel: 12.*
+            phpunit: 12.*
+          - laravel: 13.*
+            phpunit: 11.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -35,7 +43,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^11.5.3",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {


### PR DESCRIPTION
Ref #58942

This pull request updates the test workflow and development dependencies to support newer versions of PHPUnit and Laravel, and introduces more granular testing across different version combinations. The workflow matrix is expanded to test additional combinations, and exclusions are set to avoid incompatible setups.

**CI workflow improvements:**

* Added `workflow_dispatch` to the triggers in `.github/workflows/tests.yml`, allowing manual workflow runs.
* Expanded the test matrix to include multiple PHPUnit versions (`11.*`, `12.*`), and updated the job name to reflect the PHPUnit version. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR14) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR23-R31)
* Added exclusions in the matrix to prevent incompatible Laravel and PHPUnit version combinations from being tested.
* Updated the dependency installation step to explicitly require the correct PHPUnit version for each matrix job.

**Dependency updates:**

* Updated `composer.json` to allow `orchestra/testbench` version `^11.0` and `phpunit/phpunit` version `^12.0` for broader compatibility with newer Laravel and PHPUnit releases.